### PR TITLE
Support a attribute list in xsl:use-attribute-sets

### DIFF
--- a/src/xsltTokenDiagnostics.ts
+++ b/src/xsltTokenDiagnostics.ts
@@ -996,9 +996,9 @@ export class XsltTokenDiagnostics {
 							hasProblem = true;
 						}
 						if (!hasProblem && attType === AttributeType.UseAttributeSets) {
-							if (globalAttributeSetNames.indexOf(variableName) < 0 && variableName !== 'xsl:original') {
+							if (variableName.split(/ +/).some((name) => globalAttributeSetNames.indexOf(name) < 0 && name !== 'xsl:original')) {
 								token['error'] = ErrorType.AttributeSetUnresolved;
-								token.value = variableName;
+								token.value = variableName.split(/ +/).filter((name) => globalAttributeSetNames.indexOf(name) < 0);
 								problemTokens.push(token);
 								hasProblem = true;
 							}


### PR DESCRIPTION
Fixes false positive error where`xsl:use-attribute-sets` contains a space separated list of XSL attributes.